### PR TITLE
Support custom user queues, limit command overusage for certain users

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,10 +15,10 @@ bot.username= # username for bot (either your own twitch account or a separate *
 channel.name= # your twitch channel name
 client_id= # your twitch client id
 client_secrets= # your twitch client secrets
-channel.mod_permissions_list= # comma-delimited list of users with mod permissions
 server.url=irc.chat.twitch.tv # default server domain
 server.port=6667 # default server port to connect irc client to
 ```
+
 Database properties if custom loyalty point system is desired:
 ```
 db.host=
@@ -27,6 +27,18 @@ db.user=
 db.password=
 db.port=
 ```
+
+Additional (optional) properties:
+```
+channel.trused_users_list= # comma-delimited list of trusted users permitted to use mod-level commands
+approved_streamers_file= # path to filename containing line-delimited list of approved streamers to auto shoutout
+hype.message= # custom hype message for !hype command
+ignored_users_list= # comma-delimited list of users to ignore when giving an auto shoutout or any streamer shout out (i.e., nightbot or streamelements)
+queue_names_list= # comma-delimited list of queues that users can join
+```
+
+Flowerbot customization and additional documentation:
+- [Custom Queues](./docs/Queues.md)
 
 ### Usage:
 ```

--- a/docs/Queues.md
+++ b/docs/Queues.md
@@ -1,0 +1,46 @@
+# Custom Queues
+
+To add custom queues for viewers to join, simply set the property `queue_names_list=` in your `bot.properties`.
+
+Example:
+```
+queue_names_list=icecream,cake
+```
+
+To do this on the fly, simply run the following command with the list of desired queues. Note that running this command will reset and remove existing queues.
+
+```
+!queueinit <queuename1> <queuename2> ...
+```
+
+The list of queues must be comma-delimited. Any number of queues are allowed but users may only join one queue at a time. 
+
+Bot commands:
+
+Commands specific to available queues begin with `!<queuename>`. The queue name `icecream` will be used for the example uses below.
+
+- `!icecream`: if no arguments are passed to this commmand then this will add the viewer to the specified queue. If the viewer already belongs to another queue then they will be alerted and told to leave the other queue if they wish to join the new one.
+- `!icecream leave`: allows user to leave the specified queue
+
+Queue commands restricted to only the broadcaster.
+
+- `!icecream next`: Prints the next username in the queue. If there are more usernames in the queue then it will also print who is on deck (or second) in queue. If the queue is empty then a message saying so will be printed instead.
+- `!icecream win`: Increments the score of the specified queue and then prints the updated score(s) for the queue(s). 
+
+Other queue-specific commands:
+
+- `!print`: prints all of the usersnames in each available queue. 
+
+> Current queue for icecream: xcornflowerx;  Current queue for cake: xhubflowerx
+
+- `!score`: prints the current score(s) for each available queue.
+
+
+Additional broadcoaster-only permitted queue command:
+- `!queueinit <queuename1> <queuename2>`: resets or initializes the available queues to the specified list.
+
+Usage:
+> !queueinit icecream cake
+
+Output:
+> Available queue(s) to join: icecream, cake

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,11 @@
+Django==1.11.20
+Jinja2==2.9.6
+html5lib==0.999999999
+httplib2==0.11.3
+irc==16.4
+mysqlclient==1.3.14
+oauth2client==4.1.2
+playsound==1.2.2
+python-twitch-client==0.6.0
+requests==2.19.1
+urllib3==1.23

--- a/resources/bot.properties.EXAMPLE
+++ b/resources/bot.properties.EXAMPLE
@@ -19,3 +19,6 @@ server.port=6667
 # custom properties
 approved_streamers_file=
 hype.message=
+ignored_users_list=nightbot,streamelements
+rationed_users_list=
+queue_names_list=


### PR DESCRIPTION
Properties file now supports custom list of queues for viewers to join. Viewers may only join one queue at a time.
- Prints score(s) to chat with !score (any user has permissions)
- Increment score(s) and print to chat with !<queuename> win (broadcaster only permission)

Properties file now allows broadcaster to explicitly limit the number of commands that specific users can try running. (looking at you xdvardhs)

Other new properties:
- ignored users (users to ignore when giving a streamer shout out, such as nightbot)

Signed-off-by: cornflower <xcornflowerx@gmail.com>