### PR TITLE
Support custom auto shoutout messages by user

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 resources/data/approved_streamers.txt
 resources/*.properties
+resources/data/custom_shoutout_messages.txt
 .DS_Store
 *.pyc
 *.bak

--- a/README.md
+++ b/README.md
@@ -31,10 +31,13 @@ db.port=
 Additional (optional) properties:
 ```
 channel.trused_users_list= # comma-delimited list of trusted users permitted to use mod-level commands
-approved_streamers_file= # path to filename containing line-delimited list of approved streamers to auto shoutout
+auto_shoutout_users_file= # path to filename containing line-delimited list of approved twitch users to give an auto shoutout to
+custom_shoutouts_file= # path to tab-delimited file containing custom user shoutout messages for certain users
 hype.message= # custom hype message for !hype command
 ignored_users_list= # comma-delimited list of users to ignore when giving an auto shoutout or any streamer shout out (i.e., nightbot or streamelements)
+restricted_users_list = # comma-delimited list of users with restricted access to command usage
 queue_names_list= # comma-delimited list of queues that users can join
+custom.user_shoutout_message = # auto shoutout user message template. Add ${username} to auto-insert username and ${lastgameplayed} to auto-insert user's last game played
 ```
 
 Flowerbot customization and additional documentation:
@@ -42,7 +45,7 @@ Flowerbot customization and additional documentation:
 
 ### Usage:
 ```
-python flowerbot.py --properties-file /path/to/properties/file --cross-talk-channels [optional, comma-delimited list of channels to share messages to]
+python flowerbot.py --properties-file /path/to/properties/file
 ```
 
 ### Compile:

--- a/resources/bot.properties.EXAMPLE
+++ b/resources/bot.properties.EXAMPLE
@@ -17,8 +17,9 @@ server.url=irc.chat.twitch.tv
 server.port=6667
 
 # custom properties
-approved_streamers_file=
+auto_shoutout_users_file=
+custom_shoutouts_file=
 hype.message=
 ignored_users_list=nightbot,streamelements
-rationed_users_list=
+restricted_users_list=
 queue_names_list=

--- a/resources/data/custom_shoutout_messages.txt.EXAMPLE
+++ b/resources/data/custom_shoutout_messages.txt.EXAMPLE
@@ -1,0 +1,2 @@
+TWITCH_USERNAME	SHOUTOUT_MESSAGE
+flowerbot	Flowerbot is great! Follow them at https://github.com/xcornflowerx/flowerbot!


### PR DESCRIPTION
- Default auto shoutout message is hardcoded in flowerbot.py
- Override default auto shoutout message with new property 'custom.user_shoutout_message'
- Added replacement text strings for inserting twitch username and/or last game played in shoutout messages.
- Updated example properties.
- Checked in tab-delimited example file for supporting custom shoutout messages per user.
- Updated README.md

Signed-off-by: cornflower <xcornflowerx@gmail.com>